### PR TITLE
Fix remaining formatting issues with ruff format

### DIFF
--- a/examples/session_persistence.py
+++ b/examples/session_persistence.py
@@ -23,7 +23,6 @@ print("Row count:", len(df))
 async def main() -> None:
     """Demonstrate that files persist for the lifetime of an MCP session."""
     async with Client("http://localhost:9000/mcp") as client:
-
         # 1. Run code that downloads a CSV file into the workspace mounts directory.
         first_params = {
             "code": a_sync_code_first,

--- a/server/tools/run_code.py
+++ b/server/tools/run_code.py
@@ -79,7 +79,6 @@ def register(mcp: FastMCP) -> None:
 
         sid = ctx.session_id  # may be None on Streamable-HTTP
         if not sid and ctx.request_context.request:
-
             # see issue https://github.com/modelcontextprotocol/python-sdk/
             # issues/1063 for more details
             sid = ctx.request_context.request.headers.get("mcp-session-id")

--- a/tests/unit/test_sandbox_env.py
+++ b/tests/unit/test_sandbox_env.py
@@ -23,7 +23,6 @@ class TestCreateVirtualenv:
                 "server.sandbox.env.asyncio.create_subprocess_exec"
             ) as mock_subprocess,
         ):
-
             # Mock venv creation
             mock_builder = Mock()
             mock_venv.EnvBuilder.return_value = mock_builder
@@ -78,7 +77,6 @@ class TestCreateVirtualenv:
                 "server.sandbox.env.asyncio.create_subprocess_exec"
             ) as mock_subprocess,
         ):
-
             # Mock venv creation
             mock_builder = Mock()
             mock_venv.EnvBuilder.return_value = mock_builder
@@ -106,7 +104,6 @@ class TestCreateVirtualenv:
                 "server.sandbox.env.asyncio.create_subprocess_exec"
             ) as mock_subprocess,
         ):
-
             # Mock venv creation
             mock_builder = Mock()
             mock_venv.EnvBuilder.return_value = mock_builder
@@ -146,7 +143,6 @@ class TestCreateVirtualenv:
                 "server.sandbox.env.asyncio.create_subprocess_exec"
             ) as mock_subprocess,
         ):
-
             # Mock venv creation
             mock_builder = Mock()
             mock_venv.EnvBuilder.return_value = mock_builder
@@ -189,7 +185,6 @@ class TestCreateVirtualenv:
             ) as mock_subprocess,
             patch("server.sandbox.env.sys.platform", "win32"),
         ):
-
             # Mock venv creation
             mock_builder = Mock()
             mock_venv.EnvBuilder.return_value = mock_builder

--- a/tests/unit/test_sandbox_runner.py
+++ b/tests/unit/test_sandbox_runner.py
@@ -128,7 +128,6 @@ class TestRunCode:
             patch("server.sandbox.runner.asyncio.wait_for") as mock_wait_for,
             patch("server.sandbox.runner.create_virtualenv") as mock_create_venv,
         ):
-
             # Mock virtualenv creation to return the mocked python path
             mock_create_venv.return_value = mock_virtualenv_creation
 


### PR DESCRIPTION
- Reformatted examples/session_persistence.py
- Reformatted server/tools/run_code.py
- Reformatted tests/unit/test_sandbox_env.py
- Reformatted tests/unit/test_sandbox_runner.py
- All 29 files now pass ruff format --check ✅