### PR TITLE
Fix import formatting conflict between ruff and isort

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -42,6 +42,7 @@ ignore = [
 
 [lint.per-file-ignores]
 "__init__.py" = ["F401"]  # Allow unused imports
+"server/tools/__init__.py" = ["F401", "I001"]  # Allow unused imports and import formatting
 "**/test_*.py" = ["ARG", "S"]  # Relax some rules for tests
 "**/conftest.py" = ["ARG", "S"]
 

--- a/server/tools/__init__.py
+++ b/server/tools/__init__.py
@@ -1,6 +1,4 @@
 # register is called from server.main, so import here is enough
-from . import (
-    mount_file,  # noqa: F401
-    persist_artifact,  # noqa: F401
-    workspace_inspect,  # noqa: F401
-)
+from . import mount_file  # noqa: F401
+from . import persist_artifact  # noqa: F401
+from . import workspace_inspect  # noqa: F401


### PR DESCRIPTION
- Changed server/tools/__init__.py to use individual import statements (isort preference)
- Added I001 ignore rule for server/tools/__init__.py in ruff.toml
- Resolves CI/CD pipeline import formatting error
- Both ruff and isort now pass validation ✅